### PR TITLE
Add initial workflow to build robot code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,8 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    # Runs a single command using the runner's shell
     - name: Compile robot code
       run: ./gradlew build
+
+    - name: Unit Tests
+      run: ./gradlew test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+# This is a basic workflow to build robot code.
+
+name: Build
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # This grabs the WPILib docker container
+    container: wpilib/roborio-cross-ubuntu:2025-24.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v4
+
+    # Declares the repository safe and not under dubious ownership.
+    - name: Add repository to git safe directories
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+    # Grant execute permission for gradlew
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    # Runs a single command using the runner's shell
+    - name: Compile robot code
+      run: ./gradlew build


### PR DESCRIPTION
This adds a GitHub Actions workflow that will automatically attempt to build the robot code for every push to the `main` branch or whenever a pull request is opened targeting `main`. I copied the workflow from this page of the WPILib docs: https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/robot-code-ci.html 